### PR TITLE
refactor: Change library prefix to ngr

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -7,7 +7,7 @@
             "root": "projects/ng-rocketparts",
             "sourceRoot": "projects/ng-rocketparts/src",
             "projectType": "library",
-            "prefix": "rp",
+            "prefix": "ngr",
             "schematics": {
                 "@schematics/angular:component": {
                     "styleext": "scss"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3160,16 +3160,6 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
-        "cors": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-            "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-            "dev": true,
-            "requires": {
-                "object-assign": "4.1.1",
-                "vary": "1.1.2"
-            }
-        },
         "cosmiconfig": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
@@ -4123,21 +4113,6 @@
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
-        },
-        "event-stream": {
-            "version": "3.3.4",
-            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-            "dev": true,
-            "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
-                "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
-            }
         },
         "eventemitter3": {
             "version": "3.1.0",
@@ -7908,7 +7883,7 @@
                 "colors": "1.3.2",
                 "connect": "3.4.1",
                 "cors": "2.8.4",
-                "event-stream": "3.3.4",
+                "event-stream": "3.3.5",
                 "faye-websocket": "0.11.1",
                 "http-auth": "2.4.11",
                 "morgan": "1.9.0",
@@ -7938,6 +7913,16 @@
                         "utils-merge": "1.0.0"
                     }
                 },
+                "cors": {
+                    "version": "2.8.4",
+                    "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+                    "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+                    "dev": true,
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "vary": "1.1.2"
+                    }
+                },
                 "debug": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
@@ -7945,6 +7930,21 @@
                     "dev": true,
                     "requires": {
                         "ms": "0.7.1"
+                    }
+                },
+                "event-stream": {
+                    "version": "3.3.5",
+                    "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+                    "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "0.1.1",
+                        "from": "0.1.7",
+                        "map-stream": "0.0.7",
+                        "pause-stream": "0.0.11",
+                        "split": "1.0.1",
+                        "stream-combiner": "0.2.2",
+                        "through": "2.3.8"
                     }
                 },
                 "faye-websocket": {
@@ -7967,6 +7967,12 @@
                         "on-finished": "2.3.0",
                         "unpipe": "1.0.0"
                     }
+                },
+                "map-stream": {
+                    "version": "0.0.7",
+                    "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+                    "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
+                    "dev": true
                 },
                 "mime": {
                     "version": "1.4.1",
@@ -7994,6 +8000,12 @@
                     "requires": {
                         "is-wsl": "1.1.0"
                     }
+                },
+                "proxy-middleware": {
+                    "version": "0.15.0",
+                    "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+                    "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+                    "dev": true
                 },
                 "send": {
                     "version": "0.16.2",
@@ -8031,6 +8043,25 @@
                             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                             "dev": true
                         }
+                    }
+                },
+                "split": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+                    "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+                    "dev": true,
+                    "requires": {
+                        "through": "2.3.8"
+                    }
+                },
+                "stream-combiner": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+                    "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+                    "dev": true,
+                    "requires": {
+                        "duplexer": "0.1.1",
+                        "through": "2.3.8"
                     }
                 },
                 "utils-merge": {
@@ -8285,12 +8316,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
             "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-            "dev": true
-        },
-        "map-stream": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
         "map-visit": {
@@ -10447,12 +10472,6 @@
                 "ipaddr.js": "1.8.0"
             }
         },
-        "proxy-middleware": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
-            "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
-            "dev": true
-        },
         "prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -12118,15 +12137,6 @@
             "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
             "dev": true
         },
-        "split": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-            "dev": true,
-            "requires": {
-                "through": "2.3.8"
-            }
-        },
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -12233,15 +12243,6 @@
             "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.6"
-            }
-        },
-        "stream-combiner": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-            "dev": true,
-            "requires": {
-                "duplexer": "0.1.1"
             }
         },
         "stream-each": {

--- a/projects/ng-rocketparts/karma.conf.js
+++ b/projects/ng-rocketparts/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
         plugins: [
             require('karma-jasmine'),
             require('karma-chrome-launcher'),
-            require('karma-phantomjs-launcher')
+            require('karma-phantomjs-launcher'),
             require('karma-jasmine-html-reporter'),
             require('karma-coverage-istanbul-reporter'),
             require('@angular-devkit/build-angular/plugins/karma')

--- a/projects/ng-rocketparts/karma.conf.js
+++ b/projects/ng-rocketparts/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
         plugins: [
             require('karma-jasmine'),
             require('karma-chrome-launcher'),
-            require('karma-phantomjs-launcher'),
+            require('karma-phantomjs-launcher')
             require('karma-jasmine-html-reporter'),
             require('karma-coverage-istanbul-reporter'),
             require('@angular-devkit/build-angular/plugins/karma')

--- a/projects/ng-rocketparts/src/test.ts
+++ b/projects/ng-rocketparts/src/test.ts
@@ -33,6 +33,5 @@ getTestBed().initTestEnvironment(
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
-
 // And load the modules.
 context.keys().map(context);


### PR DESCRIPTION
Renamed the lib prefix from `rp` to `ngr`

I think we should merge this one first so I can rebase the others.