### PR TITLE
chore(app): update tslint to match lib prefix

### DIFF
--- a/projects/ng-rocketparts/tslint.json
+++ b/projects/ng-rocketparts/tslint.json
@@ -4,13 +4,13 @@
         "directive-selector": [
             true,
             "attribute",
-            "rp",
+            "ngr",
             "camelCase"
         ],
         "component-selector": [
             true,
             "element",
-            "rp",
+            "ngr",
             "kebab-case"
         ]
     }


### PR DESCRIPTION
Currently `tslint.json` from the library was left untouched. Now it matches the prefix provided in `angular.json`.